### PR TITLE
Add Docker & compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o tracker
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build /src/tracker ./tracker
+CMD ["./tracker"]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ a message in a configured chat.
    ```sh
    go mod download
    ```
-2. Set environment variables:
-   - `TELEGRAM_TOKEN` – your Telegram bot token.
-   - `TARGET_CHAT_ID` – chat where updates should be posted. This is optional; if not set, the first chat sending a command will be used.
+2. Set environment variable `TELEGRAM_TOKEN` with your bot token.
+   The target chat will be determined automatically from the first command or can be set using `/set_chat`.
 3. Run the bot
    ```sh
    go run ./...
@@ -30,3 +29,12 @@ Commands inside Telegram:
 
 Positions are requested from `https://api.glidernet.org/tracker/<id>`; you may
 need to adjust this endpoint if the API changes.
+
+## Docker
+
+Build the image and run the bot using docker-compose:
+```sh
+docker-compose up --build
+```
+
+Environment variable `TELEGRAM_TOKEN` can be placed in a `.env` file or exported before running compose.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  tracker:
+    build: .
+    environment:
+      - TELEGRAM_TOKEN=${TELEGRAM_TOKEN}

--- a/main.go
+++ b/main.go
@@ -253,16 +253,7 @@ func main() {
 	if token == "" {
 		log.Fatal("TELEGRAM_TOKEN must be set")
 	}
-	chatIDStr := os.Getenv("TARGET_CHAT_ID")
-	var chatID int64
-	if chatIDStr != "" {
-		var err error
-		chatID, err = strconv.ParseInt(chatIDStr, 10, 64)
-		if err != nil {
-			log.Fatalf("invalid TARGET_CHAT_ID: %v", err)
-		}
-	}
-	bot, err := NewTrackerBot(token, chatID)
+	bot, err := NewTrackerBot(token, 0)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- create Dockerfile for building the Go bot
- add docker-compose.yml for easier deployment
- document Docker usage in README
- remove all TARGET_CHAT_ID references

## Testing
- `go vet ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6841325748088323a6a98e05b0b6e12a