### PR TITLE
Fix service name and env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM golang:1.24.2-alpine AS builder
 
 WORKDIR /app
 
-COPY go.mod go.sum ./
-RUN go mod download
-
 COPY . .
+RUN go mod download
 
 # Кросс-компиляция под Linux x86_64
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a message in a configured chat.
    ```sh
    go mod download
    ```
-2. Set environment variable `TELEGRAM_TOKEN` with your bot token.
+2. Set environment variable `TELEGRAM_BOT_TOKEN` with your bot token.
    The target chat will be determined automatically from the first command or can be set using `/set_chat`.
 3. Run the bot
    ```sh
@@ -37,4 +37,4 @@ Build the image and run the bot using docker-compose:
 docker-compose up --build
 ```
 
-Environment variable `TELEGRAM_TOKEN` can be placed in a `.env` file or exported before running compose.
+Environment variable `TELEGRAM_BOT_TOKEN` can be placed in a `.env` file or exported before running compose.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.8'
 services:
-  tax-bot:
+  ogn-tracker:
     build: .
     container_name: ogn-tracker
     environment:

--- a/main.go
+++ b/main.go
@@ -249,9 +249,9 @@ func getOGNPosition(id string) (*Position, error) {
 }
 
 func main() {
-	token := os.Getenv("TELEGRAM_TOKEN")
-	if token == "" {
-		log.Fatal("TELEGRAM_TOKEN must be set")
+    token := os.Getenv("TELEGRAM_BOT_TOKEN")
+    if token == "" {
+            log.Fatal("TELEGRAM_BOT_TOKEN must be set")
 	}
 	bot, err := NewTrackerBot(token, 0)
 	if err != nil {

--- a/makefile
+++ b/makefile
@@ -4,22 +4,22 @@ IMAGE_NAME := telegram-ogn-tracker
 SERVICE := ogn-tracker
 
 build:
-	docker-compose build --no-cache
+        docker-compose build --no-cache
 
 up:
-	docker-compose up -d
+        docker-compose up -d
 
 down:
-	docker-compose down
+        docker-compose down
 
 rebuild: down build up
 
 logs:
-	docker logs -f $(SERVICE)
+        docker logs -f $(SERVICE)
 
 cleanup:
-	docker stack rm telegram-ogn-tracker || true
-	docker-compose down || true
+        docker stack rm telegram-ogn-tracker || true
+        docker-compose down || true
 	docker rm -f $(shell docker ps -aq) || true
 	docker rmi telegram-ogn-tracker telegram-ogn-tracker-ogn-tracker || true
 	docker image prune -f


### PR DESCRIPTION
## Summary
- run `go mod download` once after sources are copied
- rename compose service to `ogn-tracker`
- use `TELEGRAM_BOT_TOKEN` consistently
- revert `makefile` to `docker-compose` commands

## Testing
- `go vet ./...` *(fails: missing go.sum entry)*
- `docker-compose build --no-cache` *(fails: `docker-compose` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684137d224d48323846c690f5be2f004