### PR TITLE
Fix OGN client import

### DIFF
--- a/tracker_bot.py
+++ b/tracker_bot.py
@@ -7,7 +7,10 @@ from telegram.ext import (ApplicationBuilder, CommandHandler,
                           ContextTypes)
 
 # Library for accessing OGN data
-from ogn.client import OGNClient
+# OGNClient was moved to a submodule in newer versions of python-ogn-client.
+# Importing it from ``ogn.client`` raises ``ImportError``. Import directly from
+# the ``client`` module so the code works with recent library releases.
+from ogn.client.client import OGNClient
 
 
 class TrackerBot:


### PR DESCRIPTION
## Summary
- fix ImportError when importing OGNClient

## Testing
- `python -m py_compile tracker_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6842033ce96883238ba2923dc51b4c60