### PR TITLE
Add stop target for Docker container

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint run
+.PHONY: install lint run stop
 
 install:
 	pip install -r requirements.txt
@@ -8,3 +8,7 @@ lint:
 
 run:
 	python bot.py
+
+stop:
+	docker stop ogn-tracker || true
+	docker rm ogn-tracker || true


### PR DESCRIPTION
## Summary
- add new `stop` target to Makefile for stopping and removing the `ogn-tracker` Docker container

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6842dd4d2b348323a5b98eb4a3e1b807