### PR TITLE
Display address and username under live location

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Commands inside Telegram:
 - `/chat_id` – display the id of the current chat.
 - `/set_chat` – use the current chat for position updates.
 
-When tracking IDs, the bot sends a live location message for each address. If a
-new beacon arrives for the same address, that message is updated with the new
-coordinates instead of sending a new message.
+When tracking IDs, the bot sends a live location message for each address. The
+address and associated user name are posted in a reply to that message. If a new
+beacon arrives for the same address, the live location message is updated with
+the new coordinates instead of sending a new message.
 
 Positions are requested from `https://api.glidernet.org/tracker/<id>`; you may
 need to adjust this endpoint if the API changes.

--- a/bot.py
+++ b/bot.py
@@ -83,7 +83,8 @@ class TrackerBot:
                     self.positions[beacon_id] = {
                         "lat": beacon.get("latitude"),
                         "lon": beacon.get("longitude"),
-                        "timestamp": beacon.get("timestamp")
+                        "timestamp": beacon.get("timestamp"),
+                        "name": beacon.get("name"),
                     }
                 else:
                     logging.debug("Beacon %s filtered out", beacon_id)
@@ -198,6 +199,14 @@ class TrackerBot:
                         latitude=pos.get("lat"),
                         longitude=pos.get("lon"),
                         live_period=86400,
+                    )
+                    text = f"Address: {ogn_id}"
+                    if pos.get("name"):
+                        text += f"\nUser: {pos['name']}"
+                    await context.bot.send_message(
+                        chat_id=self.target_chat_id,
+                        text=text,
+                        reply_to_message_id=msg.message_id,
                     )
                 except Exception as exc:
                     logging.error("Failed to send location for %s: %s", ogn_id, exc)


### PR DESCRIPTION
## Summary
- attach beacon `name` when processing APRS messages
- reply to every new live location with the tracked address and user name
- document this behavior in `README`

## Testing
- `make lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e0421004832384999eec50ba240f