### PR TITLE
Remove excess log output

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -86,8 +86,6 @@ class TrackerBot:
                         "timestamp": beacon.get("timestamp"),
                         "name": beacon.get("name"),
                     }
-                else:
-                    logging.debug("Beacon %s filtered out", beacon_id)
         except AprsParseError as exc:
             logging.warning("Failed to parse beacon: %s", exc)
         except Exception as exc:


### PR DESCRIPTION
## Summary
- clean up beacon processing by removing debug log that spammed output

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6842e1ed01608323864ee8339a9901ad