### PR TITLE
Add admin ID env var and extra OGN debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,7 @@ address and associated user name are posted in a reply to that message. If a new
 beacon arrives for the same address, the live location message is updated with
 the new coordinates instead of sending a new message.
 
+The bot prints debug logs for every received OGN line and any parse errors to help diagnose missing data.
+
 Positions are requested from `https://api.glidernet.org/tracker/<id>`; you may
 need to adjust this endpoint if the API changes.


### PR DESCRIPTION
## Summary
- configure admin user ID via `ADMIN_USER_ID` env var
- log every OGN line and parse errors for easier debugging
- document new variable in README and `.env.example`

## Testing
- `make vet`


------
https://chatgpt.com/codex/tasks/task_e_6846dc141c948323a2f5356a643f1bb2