### PR TITLE
Add commands button

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Commands inside Telegram:
 - `/track_on` – enable tracking.
 - `/track_off` – disable tracking.
 - `/list` – show current tracked ids and state (with the Telegram name of the user who added each).
+- `/help` – show the list of available commands.
+
+After sending `/start`, the bot displays a keyboard with a **Commands** button that shows this list at any time.
 
 Tracking compares only the last six characters of each callsign. This means you
 can add IDs in their short form (e.g. `FE0E4A`) and they will match beacons with

--- a/main.go
+++ b/main.go
@@ -23,6 +23,20 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Register bot commands so Telegram can show a menu button.
+	commands := []tgbotapi.BotCommand{
+		{Command: "start", Description: "display a welcome message"},
+		{Command: "add", Description: "start tracking the given OGN id"},
+		{Command: "remove", Description: "stop tracking the id"},
+		{Command: "track_on", Description: "enable tracking"},
+		{Command: "track_off", Description: "disable tracking"},
+		{Command: "list", Description: "show tracked ids"},
+		{Command: "help", Description: "show command list"},
+	}
+	if _, err := bot.Request(tgbotapi.NewSetMyCommands(commands...)); err != nil {
+		log.Printf("failed to set bot commands: %v", err)
+	}
+
 	tracker := NewTracker(bot)
 	tracker.Run()
 }
@@ -93,6 +107,12 @@ func (t *Tracker) Run() {
 			t.cmdTrackOff(update.Message)
 		case "list":
 			t.cmdList(update.Message)
+		case "help":
+			t.cmdHelp(update.Message)
+		default:
+			if strings.EqualFold(update.Message.Text, "Commands") {
+				t.cmdHelp(update.Message)
+			}
 		}
 	}
 }
@@ -105,7 +125,11 @@ func (t *Tracker) cmdStart(m *tgbotapi.Message) {
 	t.mu.Lock()
 	t.chatID = m.Chat.ID
 	t.mu.Unlock()
+	keyboard := tgbotapi.NewReplyKeyboard(
+		tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("Commands")),
+	)
 	msg := tgbotapi.NewMessage(m.Chat.ID, "OGN tracker bot ready. Use /add <id> to track gliders.")
+	msg.ReplyMarkup = keyboard
 	if _, err := t.bot.Send(msg); err != nil {
 		log.Printf("failed to send start message: %v", err)
 	}
@@ -214,6 +238,21 @@ func (t *Tracker) cmdList(m *tgbotapi.Message) {
 	}
 	if _, err := t.bot.Send(tgbotapi.NewMessage(m.Chat.ID, text)); err != nil {
 		log.Printf("failed to send list: %v", err)
+	}
+}
+
+func (t *Tracker) cmdHelp(m *tgbotapi.Message) {
+	text := strings.Join([]string{
+		"/start - display a welcome message",
+		"/add <id> - start tracking the given OGN id",
+		"/remove <id> - stop tracking the id",
+		"/track_on - enable tracking",
+		"/track_off - disable tracking",
+		"/list - show current tracked ids and state",
+		"/help - show this help",
+	}, "\n")
+	if _, err := t.bot.Send(tgbotapi.NewMessage(m.Chat.ID, text)); err != nil {
+		log.Printf("failed to send help: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- register bot commands and add `/help`
- display a 'Commands' keyboard button on start
- document `/help` and keyboard in README

## Testing
- `go vet ./...`
- `go build -o /tmp/ognbot main.go`

------
https://chatgpt.com/codex/tasks/task_e_6846e8e1c6008323a40cd3bee0961a3f