### PR TITLE
Remove Commands button and set new Telegram commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Commands inside Telegram:
 - `/list` – show current tracked ids and state (with the Telegram name of the user who added each).
 - `/help` – show the list of available commands.
 
-After sending `/start`, the bot displays a keyboard with a **Commands** button that shows this list at any time.
-
 Tracking compares only the last six characters of each callsign. This means you
 can add IDs in their short form (e.g. `FE0E4A`) and they will match beacons with
 longer prefixes like `ICA3FE0E4A`.

--- a/main.go
+++ b/main.go
@@ -25,17 +25,14 @@ func main() {
 
 	// Register bot commands so Telegram can show a menu button.
 	commands := []tgbotapi.BotCommand{
-		{Command: "start", Description: "display a welcome message"},
-		{Command: "add", Description: "start tracking the given OGN id"},
-		{Command: "remove", Description: "stop tracking the id"},
-		{Command: "track_on", Description: "enable tracking"},
-		{Command: "track_off", Description: "disable tracking"},
-		{Command: "list", Description: "show tracked ids"},
-		{Command: "help", Description: "show command list"},
+		{Command: "start", Description: "главное меню"},
+		{Command: "help", Description: "справка"},
+		{Command: "upload_report", Description: "загрузить данные"},
+		{Command: "periods", Description: "показать периоды"},
+		{Command: "reset", Description: "сбросить данные"},
+		{Command: "commands", Description: "список команд"},
 	}
-	if _, err := bot.Request(tgbotapi.NewSetMyCommands(commands...)); err != nil {
-		log.Printf("failed to set bot commands: %v", err)
-	}
+	_, _ = bot.Request(tgbotapi.NewSetMyCommands(commands...))
 
 	tracker := NewTracker(bot)
 	tracker.Run()
@@ -112,10 +109,6 @@ func (t *Tracker) Run() {
 			t.cmdList(update.Message)
 		case "help":
 			t.cmdHelp(update.Message)
-		default:
-			if strings.EqualFold(update.Message.Text, "Commands") {
-				t.cmdHelp(update.Message)
-			}
 		}
 	}
 }
@@ -128,11 +121,7 @@ func (t *Tracker) cmdStart(m *tgbotapi.Message) {
 	t.mu.Lock()
 	t.chatID = m.Chat.ID
 	t.mu.Unlock()
-	keyboard := tgbotapi.NewReplyKeyboard(
-		tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("Commands")),
-	)
 	msg := tgbotapi.NewMessage(m.Chat.ID, "OGN tracker bot ready. Use /add <id> to track gliders.")
-	msg.ReplyMarkup = keyboard
 	if _, err := t.bot.Send(msg); err != nil {
 		log.Printf("failed to send start message: %v", err)
 	}


### PR DESCRIPTION
## Summary
- remove the `Commands` keyboard button in `/start`
- register new Telegram commands in `main.go`
- update README to remove mention of the Commands button

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846f150fc6c8323b77bb9a76c01fae9