### PR TITLE
Add menu button for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker-compose up -d
 
 The container reads the token from the `.env` file.
 
-Commands inside Telegram:
+Commands inside Telegram (also accessible via the menu button). The keyboard is hidden automatically when you send `/start`:
 - `/start` – display a welcome message.
 - `/add <id> [name]` – start tracking the given OGN id. If a name is supplied it will appear before your username in the location message.
 - `/remove <id>` – stop tracking the id.


### PR DESCRIPTION
## Summary
- add a chat menu button showing commands and drop `/commands`
- hide old keyboard when the bot starts
- mention the menu button in the README

## Testing
- `go vet ./...`
- `go build -o ogn-go-bot main.go`


------
https://chatgpt.com/codex/tasks/task_e_6846f2ccd0f883238f42600463dc93d4