### PR TITLE
Update /add command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The container reads the token from the `.env` file.
 
 Commands inside Telegram (also accessible via the menu button). The keyboard is hidden automatically when you send `/start`:
 - `/start` – display a welcome message.
-- `/add <id> [name]` – start tracking the given OGN id. If a name is supplied it will appear before your username in the location message.
+- `/add <id> [name]` – start tracking the given OGN id. The optional name may contain spaces and will appear before your username in location messages.
 - `/remove <id>` – stop tracking the id.
 - `/track_on` – enable tracking.
 - `/track_off` – disable tracking.
@@ -40,7 +40,8 @@ longer prefixes like `ICA3FE0E4A`.
 
 When tracking IDs, the bot sends a separate live location message for every
 address. By default the message shows your Telegram username. If you provide a
-name with `/add`, that name is shown followed by your username in parentheses.
+name with `/add`, that name (even with spaces) is shown before your username in
+parentheses.
 The text message below each location also shows when that glider was last seen
 on the network. Each message is updated independently when a new beacon is
 received for that address.

--- a/main.go
+++ b/main.go
@@ -26,11 +26,13 @@ func main() {
 
 	// Register bot commands so Telegram can show a menu button.
 	commands := []tgbotapi.BotCommand{
-		{Command: "start", Description: "главное меню"},
-		{Command: "help", Description: "справка"},
-		{Command: "upload_report", Description: "загрузить данные"},
-		{Command: "periods", Description: "показать периоды"},
-		{Command: "reset", Description: "сбросить данные"},
+		{Command: "start", Description: "display a welcome message"},
+		{Command: "add", Description: "track an OGN id"},
+		{Command: "remove", Description: "stop tracking an id"},
+		{Command: "track_on", Description: "enable tracking"},
+		{Command: "track_off", Description: "disable tracking"},
+		{Command: "list", Description: "show tracked ids"},
+		{Command: "help", Description: "show help"},
 	}
 	_, _ = bot.Request(tgbotapi.NewSetMyCommands(commands...))
 
@@ -129,7 +131,7 @@ func (t *Tracker) cmdStart(m *tgbotapi.Message) {
 	t.mu.Lock()
 	t.chatID = m.Chat.ID
 	t.mu.Unlock()
-	msg := tgbotapi.NewMessage(m.Chat.ID, "OGN tracker bot ready. Use /add <id> to track gliders.")
+	msg := tgbotapi.NewMessage(m.Chat.ID, "OGN tracker bot ready. Use /add <id> [name] to track gliders.")
 	// Hide any leftover custom keyboard from older versions of the bot.
 	msg.ReplyMarkup = tgbotapi.NewRemoveKeyboard(false)
 	if _, err := t.bot.Send(msg); err != nil {
@@ -257,7 +259,7 @@ func (t *Tracker) cmdList(m *tgbotapi.Message) {
 func (t *Tracker) cmdHelp(m *tgbotapi.Message) {
 	text := strings.Join([]string{
 		"/start - display a welcome message",
-		"/add <id> - start tracking the given OGN id",
+		"/add <id> [name] - start tracking the given OGN id; the optional name is shown in messages",
 		"/remove <id> - stop tracking the id",
 		"/track_on - enable tracking",
 		"/track_off - disable tracking",


### PR DESCRIPTION
## Summary
- clarify `/add` command usage in README and help message
- update `/add` info in `/start` reply and Telegram command list

## Testing
- `make vet`


------
https://chatgpt.com/codex/tasks/task_e_6846f7d59744832395608a9e438a5bcf