### PR TITLE
Add command keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ The container reads the token from the `.env` file.
 
 The set of available commands depends on the current session state:
 
-1. Before you run `/start` only `/start` and `/help` are available.
+1. Before you run `/start` only `/start` is available.
 2. After `/start` you can also use `/start_session` and `/status`.
 3. Running `/start_session` unlocks the full command set: `/add`, `/remove`, `/track_on`, `/list`, and `/status`. When tracking is active, `/track_on` is replaced by `/track_off`.
 4. Calling `/start_session` again clears all added addresses and restarts the session.
 
 Commands inside Telegram (available via the menu button or the on-screen keyboard below the input field):
-- `/start` – display a welcome message and show how to enable commands.
+- `/start` – display a welcome message and show how to enable commands (this command is not shown on the keyboard).
 - `/start_session` – start or reset the session and unlock commands.
 - `/add <id> [name]` – start tracking the given OGN id. The optional name may contain spaces and will appear before your username in location messages.
 - `/remove <id>` – stop tracking the id.
@@ -41,7 +41,6 @@ Commands inside Telegram (available via the menu button or the on-screen keyboar
 - `/track_off` – disable tracking and keep addresses.
 - `/list` – show current tracked ids and state (with the Telegram name of the user who added each).
 - `/status` – show current state.
-- `/help` – show the list of available commands.
 
 Tracking compares only the last six characters of each callsign. This means you
 can add IDs in their short form (e.g. `FE0E4A`) and they will match beacons with

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The set of available commands depends on the current session state:
 3. Running `/start_session` unlocks the full command set: `/add`, `/remove`, `/track_on`, `/list`, and `/status`. When tracking is active, `/track_on` is replaced by `/track_off`.
 4. Calling `/start_session` again clears all added addresses and restarts the session.
 
-Commands inside Telegram (available via the menu button):
+Commands inside Telegram:
  - `/start` – display a welcome message and show how to enable commands.
  - `/start_session` – start or reset the session and unlock commands.
 - `/add <id> [name]` – start tracking the given OGN id. The optional name may contain spaces and will appear before your username in location messages.

--- a/README.md
+++ b/README.md
@@ -27,20 +27,21 @@ The container reads the token from the `.env` file.
 
 The set of available commands depends on the current session state:
 
-1. Before you run `/start` only `/start` is available.
+1. Before you run `/start` only `/start` and `/help` are available.
 2. After `/start` you can also use `/start_session` and `/status`.
 3. Running `/start_session` unlocks the full command set: `/add`, `/remove`, `/track_on`, `/list`, and `/status`. When tracking is active, `/track_on` is replaced by `/track_off`.
 4. Calling `/start_session` again clears all added addresses and restarts the session.
 
-Commands inside Telegram (available via the menu button or the on-screen keyboard below the input field):
-- `/start` – display a welcome message and show how to enable commands (this command is not shown on the keyboard).
-- `/start_session` – start or reset the session and unlock commands.
+Commands inside Telegram (available via the menu button):
+ - `/start` – display a welcome message and show how to enable commands.
+ - `/start_session` – start or reset the session and unlock commands.
 - `/add <id> [name]` – start tracking the given OGN id. The optional name may contain spaces and will appear before your username in location messages.
 - `/remove <id>` – stop tracking the id.
 - `/track_on` – enable tracking (replaced by `/track_off` once active).
 - `/track_off` – disable tracking and keep addresses.
 - `/list` – show current tracked ids and state (with the Telegram name of the user who added each).
 - `/status` – show current state.
+- `/help` – show the list of available commands.
 
 Tracking compares only the last six characters of each callsign. This means you
 can add IDs in their short form (e.g. `FE0E4A`) and they will match beacons with

--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ docker-compose up -d
 The container reads the token from the `.env` file.
 
 Commands inside Telegram (available via the menu button or the on-screen keyboard below the input field):
-- `/start` – display a welcome message.
+- `/start` – display a welcome message and show how to enable commands.
+- `/start_session` – unlock all bot commands.
 - `/add <id> [name]` – start tracking the given OGN id. The optional name may contain spaces and will appear before your username in location messages.
 - `/remove <id>` – stop tracking the id.
-- `/track_on` – enable tracking.
-- `/track_off` – disable tracking.
+- `/track_on` – enable tracking (hidden if already enabled).
+- `/track_off` – disable tracking (hidden until tracking is enabled).
 - `/list` – show current tracked ids and state (with the Telegram name of the user who added each).
+- `/status` – show current state.
 - `/help` – show the list of available commands.
 
 Tracking compares only the last six characters of each callsign. This means you

--- a/README.md
+++ b/README.md
@@ -25,13 +25,20 @@ docker-compose up -d
 
 The container reads the token from the `.env` file.
 
+The set of available commands depends on the current session state:
+
+1. Before you run `/start` only `/start` and `/help` are available.
+2. After `/start` you can also use `/start_session` and `/status`.
+3. Running `/start_session` unlocks the full command set: `/add`, `/remove`, `/track_on`, `/list`, and `/status`. When tracking is active, `/track_on` is replaced by `/track_off`.
+4. Calling `/start_session` again clears all added addresses and restarts the session.
+
 Commands inside Telegram (available via the menu button or the on-screen keyboard below the input field):
 - `/start` – display a welcome message and show how to enable commands.
-- `/start_session` – unlock all bot commands.
+- `/start_session` – start or reset the session and unlock commands.
 - `/add <id> [name]` – start tracking the given OGN id. The optional name may contain spaces and will appear before your username in location messages.
 - `/remove <id>` – stop tracking the id.
-- `/track_on` – enable tracking (hidden if already enabled).
-- `/track_off` – disable tracking (hidden until tracking is enabled).
+- `/track_on` – enable tracking (replaced by `/track_off` once active).
+- `/track_off` – disable tracking and keep addresses.
 - `/list` – show current tracked ids and state (with the Telegram name of the user who added each).
 - `/status` – show current state.
 - `/help` – show the list of available commands.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker-compose up -d
 
 The container reads the token from the `.env` file.
 
-Commands inside Telegram (also accessible via the menu button). The keyboard is hidden automatically when you send `/start`:
+Commands inside Telegram (available via the menu button or the on-screen keyboard below the input field):
 - `/start` – display a welcome message.
 - `/add <id> [name]` – start tracking the given OGN id. The optional name may contain spaces and will appear before your username in location messages.
 - `/remove <id>` – stop tracking the id.


### PR DESCRIPTION
## Summary
- add a reply keyboard with all bot commands
- display the keyboard on `/start` and `/help`
- show the keyboard when the bot is added to a group
- update README instructions

## Testing
- `go build`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846ff2182388323a0a55b47c405404f