### PR TITLE
Fix build command to compile all files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 
 # Cross-compile for Linux amd64
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-RUN go build -o bot main.go
+RUN go build -o bot .
 
 FROM alpine:latest
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains a Go implementation (`main.go`) of a Telegram bot that 
    ```sh
    make run
    ```
-   This starts `go run main.go`.
+   This starts `go run .`.
 3. To build a standalone binary:
     ```sh
     make build-go

--- a/makefile
+++ b/makefile
@@ -4,13 +4,13 @@ IMAGE_NAME := telegram-ogn-tracker
 SERVICE := ogn-tracker
 
 run: vet
-	go run main.go
+        go run .
 
 vet:
 	go vet ./...
 
 build-go:
-	go build -o ogn-go-bot main.go
+        go build -o ogn-go-bot .
 
 stop:
 	docker stop $(SERVICE) || true


### PR DESCRIPTION
## Summary
- build the bot using the whole module
- adjust makefile run/build-go commands
- update README instructions

## Testing
- `go vet ./...`
- `go build -o /tmp/ogn-bot-test .`


------
https://chatgpt.com/codex/tasks/task_e_684756e92e848323b5dff09d1d92abb4