### PR TITLE
Add APRS client shutdown on track_off

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,31 +10,47 @@ import (
 )
 
 func (t *Tracker) runClient() {
-	log.Println("OGN client started")
-	err := t.aprs.Run(func(line string) {
-		log.Printf("raw OGN line: %s", line)
-		msg, err := parser.Parse(line)
-		if err != nil {
-			log.Printf("failed to parse line: %v", err)
-			return
-		}
-		origID := msg.Callsign
-		id := shortID(origID)
-		t.mu.Lock()
-		if info, ok := t.tracking[id]; ok {
-			info.Position = msg
-			info.LastUpdate = time.Now()
-			t.tracking[id] = info
-			log.Printf("received beacon for %s (orig %s): lat %.5f lon %.5f", id, origID, msg.Latitude, msg.Longitude)
-		} else {
-			log.Printf("ignoring untracked id %s", origID)
-		}
-		t.mu.Unlock()
-	}, true)
-	if err != nil {
-		log.Printf("OGN client error: %v", err)
-	}
-	log.Println("OGN client stopped")
+        log.Println("OGN client started")
+        for {
+                t.mu.Lock()
+                if !t.trackingOn {
+                        t.mu.Unlock()
+                        break
+                }
+                t.mu.Unlock()
+
+                err := t.aprs.Run(func(line string) {
+                        log.Printf("raw OGN line: %s", line)
+                        msg, err := parser.Parse(line)
+                        if err != nil {
+                                log.Printf("failed to parse line: %v", err)
+                                return
+                        }
+                        origID := msg.Callsign
+                        id := shortID(origID)
+                        t.mu.Lock()
+                        if info, ok := t.tracking[id]; ok {
+                                info.Position = msg
+                                info.LastUpdate = time.Now()
+                                t.tracking[id] = info
+                                log.Printf("received beacon for %s (orig %s): lat %.5f lon %.5f", id, origID, msg.Latitude, msg.Longitude)
+                        } else {
+                                log.Printf("ignoring untracked id %s", origID)
+                        }
+                        t.mu.Unlock()
+                }, false)
+                if err != nil {
+                        t.mu.Lock()
+                        active := t.trackingOn
+                        t.mu.Unlock()
+                        if active {
+                                log.Printf("OGN client error: %v", err)
+                                time.Sleep(5 * time.Second)
+                                continue
+                        }
+                }
+        }
+        log.Println("OGN client stopped")
 }
 
 func (t *Tracker) sendUpdates() {

--- a/commands.go
+++ b/commands.go
@@ -37,6 +37,7 @@ func (t *Tracker) cmdStartSession(m *tgbotapi.Message) {
 	}
 	t.sessionActive = true
 	t.chatID = m.Chat.ID
+	t.updateFilter()
 	t.mu.Unlock()
 
 	msg := tgbotapi.NewMessage(m.Chat.ID, "Session started. You can now use all commands.")
@@ -70,6 +71,7 @@ func (t *Tracker) cmdAdd(m *tgbotapi.Message) {
 	} else {
 		t.tracking[id] = &TrackInfo{Name: display, Username: username}
 	}
+	t.updateFilter()
 	t.mu.Unlock()
 
 	if _, err := t.bot.Send(tgbotapi.NewMessage(m.Chat.ID, "Added "+id)); err != nil {
@@ -89,6 +91,7 @@ func (t *Tracker) cmdRemove(m *tgbotapi.Message) {
 	t.mu.Lock()
 	t.chatID = m.Chat.ID
 	delete(t.tracking, id)
+	t.updateFilter()
 	t.mu.Unlock()
 	if _, err := t.bot.Send(tgbotapi.NewMessage(m.Chat.ID, "Removed "+id)); err != nil {
 		log.Printf("failed to confirm remove: %v", err)
@@ -112,6 +115,7 @@ func (t *Tracker) cmdTrackOn(m *tgbotapi.Message) {
 		return
 	}
 	t.trackingOn = true
+	t.updateFilter()
 	t.chatID = m.Chat.ID
 	t.mu.Unlock()
 	go t.runClient()

--- a/tracker.go
+++ b/tracker.go
@@ -57,6 +57,24 @@ func shortID(id string) string {
 	return id[len(id)-6:]
 }
 
+// updateFilter rebuilds the APRS filter based on the currently tracked IDs.
+// When tracking is active, the client connection is restarted so the new
+// filter takes effect.
+func (t *Tracker) updateFilter() {
+	ids := make([]string, 0, len(t.tracking))
+	for id := range t.tracking {
+		ids = append(ids, id)
+	}
+	if len(ids) > 0 {
+		t.aprs.Filter = "b/" + strings.Join(ids, "/")
+	} else {
+		t.aprs.Filter = ""
+	}
+	if t.trackingOn {
+		t.aprs.Disconnect()
+	}
+}
+
 func NewTracker(bot *tgbotapi.BotAPI) *Tracker {
 	return &Tracker{
 		bot:            bot,


### PR DESCRIPTION
## Summary
- ensure OGN client loop stops once `/track_off` is issued
- manually reconnect while tracking is on

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6848909d5a18832397a2f65b9ecfdc55