### PR TITLE
Improve rebuild cleanup for Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN go build -o bot ./cmd/bot
 
 FROM alpine:latest
 
+# pass build version to the final image
+ARG APP_VERSION="dev"
+LABEL org.opencontainers.image.version=$APP_VERSION
+
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /root/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 version: '3.8'
 services:
   ogn-tracker:
-    build: .
+    image: telegram-ogn-tracker:latest
+    build:
+      context: .
+      args:
+        APP_VERSION: ${APP_VERSION:-dev}
     container_name: ogn-tracker
     environment:
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: run vet build-go stop build up down rebuild logs reset cleanup
+.PHONY: run vet build-go stop build up down rebuild logs reset cleanup prune-images
 
 IMAGE_NAME := telegram-ogn-tracker
 SERVICE := ogn-tracker
@@ -17,7 +17,8 @@ stop:
 	docker rm $(SERVICE) || true
 
 build:
-	docker-compose build --no-cache
+	docker-compose build --no-cache --force-rm
+	$(MAKE) prune-images
 
 up:
 	docker-compose up -d
@@ -26,6 +27,9 @@ down:
 	docker-compose down
 
 rebuild: down build up
+
+prune-images:
+	docker image prune -f
 
 logs:
 	docker logs -f $(SERVICE)


### PR DESCRIPTION
## Summary
- tag built Docker image and allow version build arg
- clean up dangling images after builds
- pass build version from docker-compose

## Testing
- `make vet`
- `make build-go`


------
https://chatgpt.com/codex/tasks/task_e_68489b6119a0832398a0c27f7715a234