### PR TITLE
Fix APRS filter with short IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Commands inside Telegram:
 Tracking compares only the last six characters of each callsign. This means you
 can add IDs in their short form (e.g. `FE0E4A`) and they will match beacons with
 longer prefixes like `ICA3FE0E4A`.
+When any ID is added in this short form, APRS server filtering is disabled so
+that beacons with longer prefixes still reach the bot.
 
 When tracking IDs, the bot sends a separate live location message for every
 address. By default the message shows your Telegram username. If you provide a

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -62,10 +62,14 @@ func shortID(id string) string {
 // filter takes effect.
 func (t *Tracker) updateFilter() {
 	ids := make([]string, 0, len(t.tracking))
+	filterable := true
 	for id := range t.tracking {
 		ids = append(ids, id)
+		if len(id) <= 6 {
+			filterable = false
+		}
 	}
-	if len(ids) > 0 {
+	if len(ids) > 0 && filterable {
 		t.aprs.Filter = "b/" + strings.Join(ids, "/")
 	} else {
 		t.aprs.Filter = ""


### PR DESCRIPTION
## Summary
- update filtering logic: if any ID is shorter than 7 chars, disable APRS filter
- document that short IDs disable filtering

## Testing
- `make vet`


------
https://chatgpt.com/codex/tasks/task_e_68489d595d488323863a0a7d5fe7c8b9