### PR TITLE
Add venue-based location messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,12 @@ longer prefixes like `ICA3FE0E4A`.
 When any ID is added in this short form, APRS server filtering is disabled so
 that beacons with longer prefixes still reach the bot.
 
-When tracking IDs, the bot sends a separate live location message for every
-address. By default the message shows your Telegram username. If you provide a
-name with `/add`, that name (even with spaces) is shown before your username in
-parentheses.
-The text message below each location also shows when that glider was last seen
-on the network. Each message is updated independently when a new beacon is
-received for that address.
+When tracking IDs, the bot sends a venue message for each address. The venue
+title displays the name provided with `/add` followed by the Telegram username
+in parentheses. Each time a beacon is received, the previous venue message is
+deleted and a new one is sent so the information stays up to date. The text
+message below each location still shows when that glider was last seen on the
+network and is updated independently for every address.
 
 The bot prints debug logs for every received OGN line and any parse errors to help diagnose missing data.
 

--- a/internal/tracker/client.go
+++ b/internal/tracker/client.go
@@ -99,47 +99,53 @@ func (t *Tracker) sendUpdates() {
 			msgID := info.MessageID
 			textID := info.TextID
 
+			// Remove previous messages to avoid duplicates.
 			if msgID != 0 {
-				edit := tgbotapi.EditMessageLiveLocationConfig{
-					BaseEdit: tgbotapi.BaseEdit{
-						ChatID:    chatID,
-						MessageID: msgID,
-					},
-					Latitude:  info.Position.Latitude,
-					Longitude: info.Position.Longitude,
-				}
-				if _, err := t.bot.Request(edit); err != nil {
-					log.Printf("failed to edit location for %s: %v", id, err)
-				} else {
-					log.Printf("updated location for %s", id)
+				del := tgbotapi.NewDeleteMessage(chatID, msgID)
+				if _, err := t.bot.Request(del); err != nil {
+					log.Printf("failed to delete old location for %s: %v", id, err)
 				}
 				if textID != 0 {
-					editText := tgbotapi.NewEditMessageText(chatID, textID, text)
-					if _, err := t.bot.Send(editText); err != nil {
-						log.Printf("failed to edit text for %s: %v", id, err)
+					delTxt := tgbotapi.NewDeleteMessage(chatID, textID)
+					if _, err := t.bot.Request(delTxt); err != nil {
+						log.Printf("failed to delete old text for %s: %v", id, err)
 					}
 				}
-			} else {
-				loc := tgbotapi.NewLocation(chatID, info.Position.Latitude, info.Position.Longitude)
-				loc.LivePeriod = 86400
-				msg, err := t.bot.Send(loc)
-				if err != nil {
-					log.Printf("failed to send location for %s: %v", id, err)
-					continue
-				}
-				textMsg, err := t.bot.Send(tgbotapi.NewMessage(chatID, text))
-				if err != nil {
-					log.Printf("failed to send address message for %s: %v", id, err)
-				}
-				t.mu.Lock()
-				if info, ok := t.tracking[id]; ok {
-					info.MessageID = msg.MessageID
-					info.TextID = textMsg.MessageID
-					t.tracking[id] = info
-				}
-				t.mu.Unlock()
-				log.Printf("sent location for %s", id)
 			}
+
+			title := id
+			if info.Name != "" {
+				title = info.Name
+				if info.Username != "" {
+					title += " (@" + info.Username + ")"
+				}
+			} else if info.Username != "" {
+				title = "@" + info.Username
+			}
+
+			addr := id
+			if info.Username != "" {
+				addr = "@" + info.Username
+			}
+
+			venue := tgbotapi.NewVenue(chatID, title, addr, info.Position.Latitude, info.Position.Longitude)
+			msg, err := t.bot.Send(venue)
+			if err != nil {
+				log.Printf("failed to send venue for %s: %v", id, err)
+				continue
+			}
+			textMsg, err := t.bot.Send(tgbotapi.NewMessage(chatID, text))
+			if err != nil {
+				log.Printf("failed to send address message for %s: %v", id, err)
+			}
+			t.mu.Lock()
+			if info, ok := t.tracking[id]; ok {
+				info.MessageID = msg.MessageID
+				info.TextID = textMsg.MessageID
+				t.tracking[id] = info
+			}
+			t.mu.Unlock()
+			log.Printf("sent venue for %s", id)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- send venue messages with name/username and coordinates
- document venue messages in README

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68495a4ccbb483238ea4d8afe42c4343