### PR TITLE
Stop user mention in location update text

### DIFF
--- a/internal/tracker/client.go
+++ b/internal/tracker/client.go
@@ -82,10 +82,10 @@ func (t *Tracker) sendUpdates() {
 				if info.Name != "" {
 					text += info.Name
 					if info.Username != "" {
-						text += " (@" + info.Username + ")"
+						text += " (" + info.Username + ")"
 					}
 				} else {
-					text += "@" + info.Username
+					text += info.Username
 				}
 			}
 			if !info.LastUpdate.IsZero() {


### PR DESCRIPTION
## Summary
- remove the leading `@` symbol from the username in live location updates so Telegram doesn't ping users

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68496652b7cc8323994dd2f946026d9d